### PR TITLE
Reuse tsserver process

### DIFF
--- a/src/integration-test/go-to-definition.test.ts
+++ b/src/integration-test/go-to-definition.test.ts
@@ -1,11 +1,9 @@
-import { jest } from '@jest/globals';
 import dedent from 'dedent';
 import { run } from '../runner.js';
-import { getModuleDefinitions, getMultipleIdentifierDefinitions } from '../test/tsserver.js';
+import { createTSServer } from '../test/tsserver.js';
 import { createFixtures, getFixturePath } from '../test/util.js';
 
-// It is heavy test, so increase timeout.
-jest.setTimeout(60 * 1000); // 60s
+const server = await createTSServer();
 
 const defaultOptions = {
   pattern: 'test/**/*.{css,scss}',
@@ -13,6 +11,10 @@ const defaultOptions = {
   declarationMap: true,
   cwd: getFixturePath('/'),
 };
+
+afterAll(async () => {
+  await server.exit();
+});
 
 test('basic', async () => {
   createFixtures({
@@ -44,7 +46,7 @@ test('basic', async () => {
     `,
   });
   await run({ ...defaultOptions });
-  const results = await getMultipleIdentifierDefinitions(getFixturePath(`/test/1.css`), [
+  const results = await server.getMultipleIdentifierDefinitions(getFixturePath(`/test/1.css`), [
     'basic',
     'cascading',
     'pseudo_class_1',
@@ -223,7 +225,7 @@ test('basic', async () => {
       },
     ]
   `);
-  const moduleDefinitions = await getModuleDefinitions(getFixturePath('/test/1.css'));
+  const moduleDefinitions = await server.getModuleDefinitions(getFixturePath('/test/1.css'));
   expect(moduleDefinitions).toMatchInlineSnapshot(`
     [
       { file: "<fixtures>/test/1.css", text: "", start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
@@ -248,7 +250,7 @@ test('imported tokens', async () => {
     `,
   });
   await run({ ...defaultOptions });
-  const results = await getMultipleIdentifierDefinitions(getFixturePath(`/test/1.css`), ['a', 'b', 'c', 'd']);
+  const results = await server.getMultipleIdentifierDefinitions(getFixturePath(`/test/1.css`), ['a', 'b', 'c', 'd']);
   expect(results).toMatchInlineSnapshot(`
     [
       {
@@ -307,7 +309,7 @@ test('with transformer', async () => {
     `,
   });
   await run({ ...defaultOptions });
-  const results = await getMultipleIdentifierDefinitions(getFixturePath(`/test/1.scss`), [
+  const results = await server.getMultipleIdentifierDefinitions(getFixturePath(`/test/1.scss`), [
     'basic',
     'nesting',
     'nesting_1',

--- a/src/test/tsserver.ts
+++ b/src/test/tsserver.ts
@@ -1,11 +1,21 @@
 import { readFileSync } from 'fs';
+import { mkdir, writeFile as nativeWriteFile } from 'fs/promises';
+import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { promisify } from 'util';
 import serverHarness from '@typescript/server-harness';
+import _glob from 'glob';
 import { resolve } from 'import-meta-resolve';
 import lineColumn from 'line-column';
+import type { UpdateOpenRequest, DefinitionResponse, DefinitionRequest } from 'typescript/lib/protocol.js';
 import { getFixturePath } from './util.js';
 
-// TODO: refactor this
+const glob = promisify(_glob);
+
+async function writeFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  return nativeWriteFile(path, content, 'utf8');
+}
 
 type Definition = {
   /** The path of the destination file */
@@ -28,42 +38,7 @@ type Definition = {
   };
 };
 
-type DefinitionResponse = {
-  seq: number;
-  type: 'response';
-  command: 'definition';
-  success: boolean;
-  body: [
-    {
-      /** The path of the destination file */
-      file: string;
-      /** inclusive */
-      start: {
-        /** line, 1-based */
-        line: number;
-        /** column, 1-based */
-        offset: number;
-      };
-      /** exclusive */
-      end: {
-        /** line, 1-based */
-        line: number;
-        /** column, 1-based */
-        offset: number;
-      };
-    },
-  ];
-};
-
-export async function getIdentifierDefinitions(filePath: string, identifier: string): Promise<Definition[]> {
-  const results = await getMultipleIdentifierDefinitions(filePath, [identifier]);
-  return results[0]!.definitions;
-}
-
-export async function getMultipleIdentifierDefinitions(
-  filePath: string,
-  identifiers: string[],
-): Promise<{ identifier: string; definitions: Definition[] }[]> {
+export async function createTSServer() {
   const server = serverHarness.launchServer(
     fileURLToPath(await resolve('typescript/lib/tsserver.js', import.meta.url)),
     [
@@ -72,105 +47,107 @@ export async function getMultipleIdentifierDefinitions(
     ],
   );
 
-  const tmpFilePath = getFixturePath('/server-harness/tmp.ts');
-  const tmpFileContent = [
-    `import styles from '${filePath}';`,
-    ...identifiers.map((identifier) => `styles.${identifier};`),
-  ].join('\n');
+  return {
+    async getIdentifierDefinitions(filePath: string, identifier: string): Promise<Definition[]> {
+      const results = await this.getMultipleIdentifierDefinitions(filePath, [identifier]);
+      return results[0]!.definitions;
+    },
+    async getMultipleIdentifierDefinitions(
+      filePath: string,
+      identifiers: string[],
+    ): Promise<{ identifier: string; definitions: Definition[] }[]> {
+      const tmpFilePath = getFixturePath('/server-harness/tmp.ts');
+      const tmpFileContent = [
+        `import styles from '${filePath}';`,
+        ...identifiers.map((identifier) => `styles.${identifier};`),
+      ].join('\n');
+      await writeFile(tmpFilePath, tmpFileContent);
 
-  await server.message({
-    type: 'request',
-    command: 'updateOpen',
-    arguments: {
-      changedFiles: [],
-      closedFiles: [],
-      openFiles: [
-        {
+      await this.refreshCache();
+
+      const results: { identifier: string; definitions: Definition[] }[] = [];
+
+      for (let i = 0; i < identifiers.length; i++) {
+        const response: DefinitionResponse = await server.message({
+          seq: 0,
+          type: 'request',
+          command: 'definition',
+          arguments: {
+            file: tmpFilePath,
+            line: i + 2, // line, 1-based
+            offset: 8, // column, 1-based
+          },
+        } as DefinitionRequest);
+        const definitions: Definition[] = response.body!.map((definition) => {
+          const { file, start, end } = definition;
+          const fileContent = readFileSync(file, 'utf-8');
+          const startIndex = lineColumn(fileContent).toIndex(start.line, start.offset);
+          const endIndex = lineColumn(fileContent).toIndex(end.line, end.offset);
+          const text = fileContent.slice(startIndex, endIndex);
+          return { file, text, start, end };
+        });
+        results.push({ identifier: identifiers[i]!, definitions });
+      }
+      return results;
+    },
+    async getModuleDefinitions(filePath: string): Promise<Definition[]> {
+      await this.refreshCache();
+
+      const tmpFilePath = getFixturePath('/server-harness/tmp.ts');
+      const tmpFileContent = `import styles from '${filePath}';`;
+
+      await writeFile(tmpFilePath, tmpFileContent);
+
+      await this.refreshCache();
+
+      const response: DefinitionResponse = await server.message({
+        seq: 0,
+        type: 'request',
+        command: 'definition',
+        arguments: {
           file: tmpFilePath,
-          fileContent: tmpFileContent,
-          projectRootPath: getFixturePath('/server-harness'),
-          scriptKindName: 'TS', // It's easy to get this wrong when copy-pasting
+          line: 1, // line, 1-based
+          offset: 20, // column, 1-based
         },
-      ],
+      } as DefinitionRequest);
+      const definitions: Definition[] = response.body!.map((definition) => {
+        const { file, start, end } = definition;
+        const fileContent = readFileSync(file, 'utf-8');
+        const startIndex = lineColumn(fileContent).toIndex(start.line, start.offset);
+        const endIndex = lineColumn(fileContent).toIndex(end.line, end.offset);
+        const text = fileContent.slice(startIndex, endIndex);
+        return { file, text, start, end };
+      });
+      return definitions;
     },
-  });
+    async refreshCache() {
+      // tsserver caches the contents of opened files.
+      // When a file is updated, its cache remains with the old content.
+      // Therefore we need to overwrite the cache with the latest content.
 
-  const results: { identifier: string; definitions: Definition[] }[] = [];
+      const fixtureFilePaths = await glob(getFixturePath('/**/*.ts'), { dot: true });
+      // latest contents
+      const openFiles: UpdateOpenRequest['arguments']['openFiles'] = fixtureFilePaths.map((filePath) => ({
+        file: filePath,
+        fileContent: readFileSync(filePath, 'utf-8'),
+        projectRootPath: getFixturePath('/server-harness'),
+        scriptKindName: 'TS', // It's easy to get this wrong when copy-pasting
+      }));
 
-  for (let i = 0; i < identifiers.length; i++) {
-    const response: DefinitionResponse = await server.message({
-      type: 'request',
-      command: 'definition',
-      arguments: {
-        file: tmpFilePath,
-        line: i + 2, // line, 1-based
-        offset: 8, // column, 1-based
-      },
-    });
-    const definitions: Definition[] = response.body.map((definition) => {
-      const { file, start, end } = definition;
-      const fileContent = readFileSync(file, 'utf-8');
-      const startIndex = lineColumn(fileContent).toIndex(start.line, start.offset);
-      const endIndex = lineColumn(fileContent).toIndex(end.line, end.offset);
-      const text = fileContent.slice(startIndex, endIndex);
-      return { file, text, start, end };
-    });
-    results.push({ identifier: identifiers[i]!, definitions });
-  }
-
-  await server.message({ command: 'exit' });
-
-  return results;
-}
-
-export async function getModuleDefinitions(filePath: string): Promise<Definition[]> {
-  const server = serverHarness.launchServer(
-    fileURLToPath(await resolve('typescript/lib/tsserver.js', import.meta.url)),
-    [
-      // ATA generates some extra network traffic and isn't usually relevant when profiling
-      '--disableAutomaticTypingAcquisition',
-    ],
-  );
-
-  const tmpFilePath = getFixturePath('/server-harness/tmp.ts');
-  const tmpFileContent = `import styles from '${filePath}';`;
-
-  await server.message({
-    type: 'request',
-    command: 'updateOpen',
-    arguments: {
-      changedFiles: [],
-      closedFiles: [],
-      openFiles: [
-        {
-          file: tmpFilePath,
-          fileContent: tmpFileContent,
-          projectRootPath: getFixturePath('/server-harness'),
-          scriptKindName: 'TS', // It's easy to get this wrong when copy-pasting
+      // override the cache
+      await server.message({
+        seq: 0,
+        type: 'request',
+        command: 'updateOpen',
+        arguments: {
+          changedFiles: [],
+          closedFiles: [],
+          openFiles,
         },
-      ],
+      } as UpdateOpenRequest);
     },
-  });
-
-  const response: DefinitionResponse = await server.message({
-    type: 'request',
-    command: 'definition',
-    arguments: {
-      file: tmpFilePath,
-      line: 1, // line, 1-based
-      offset: 20, // column, 1-based
+    exit: async () => {
+      await server.message({ command: 'exit' });
     },
-  });
-  const definitions: Definition[] = response.body.map((definition) => {
-    const { file, start, end } = definition;
-    const fileContent = readFileSync(file, 'utf-8');
-    const startIndex = lineColumn(fileContent).toIndex(start.line, start.offset);
-    const endIndex = lineColumn(fileContent).toIndex(end.line, end.offset);
-    const text = fileContent.slice(startIndex, endIndex);
-    return { file, text, start, end };
-  });
-
-  await server.message({ command: 'exit' });
-
-  return definitions;
+  };
 }


### PR DESCRIPTION
Test execution time is improved.

## Before
```console
pnpm run test go-to

> happy-css-modules@0.3.0 test /Users/mizdra/src/github.com/mizdra/happy-css-modules
> NODE_OPTIONS="--experimental-vm-modules $NODE_OPTIONS" jest "go-to"

(node:66586) ExperimentalWarning: VM Modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/integration-test/go-to-definition.test.ts
  ✓ basic (713 ms)
  ✓ imported tokens (345 ms)
  ✓ with transformer (465 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   4 passed, 4 total
Time:        1.9 s, estimated 2 s
Ran all test suites matching /go-to/i.
```

## After
```console
$ pnpm run test go-to

> happy-css-modules@0.3.0 test /Users/mizdra/src/github.com/mizdra/happy-css-modules
> NODE_OPTIONS="--experimental-vm-modules $NODE_OPTIONS" jest "go-to"

(node:66711) ExperimentalWarning: VM Modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/integration-test/go-to-definition.test.ts
  ✓ basic (376 ms)
  ✓ imported tokens (25 ms)
  ✓ with transformer (142 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   4 passed, 4 total
Time:        0.926 s, estimated 1 s
Ran all test suites matching /go-to/i.
```