### PR TITLE
Use swc instead of babel

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,8 +1,0 @@
-// @ts-check
-
-/** @type {import('@babel/core').TransformOptions} */
-const config = {
-  presets: ['@babel/preset-typescript'],
-};
-
-module.exports = config;

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -15,6 +15,9 @@ const config = {
     // Map `./**/xxx.js` to `./**/xxx` (for ESM)
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  transform: {
+    '^.+\\.(t|j)sx?$': '@swc/jest',
+  },
   // for ESM
   resolver: join(dir, 'src/test/jest/resolver.cjs'),
 };

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "@jest/types": "^29.0.3",
     "@mizdra/eslint-config-mizdra": "^1.2.0",
     "@mizdra/prettier-config-mizdra": "^1.0.0",
+    "@swc/core": "^1.3.8",
+    "@swc/jest": "^0.2.23",
     "@types/babel__core": "^7.1.19",
     "@types/dedent": "^0.7.0",
     "@types/glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -55,15 +55,12 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.18.13",
-    "@babel/preset-typescript": "^7.18.6",
     "@jest/globals": "^29.0.3",
     "@jest/types": "^29.0.3",
     "@mizdra/eslint-config-mizdra": "^1.2.0",
     "@mizdra/prettier-config-mizdra": "^1.0.0",
     "@swc/core": "^1.3.8",
     "@swc/jest": "^0.2.23",
-    "@types/babel__core": "^7.1.19",
     "@types/dedent": "^0.7.0",
     "@types/glob": "^7.2.0",
     "@types/jest": "^29.0.0",
@@ -75,7 +72,6 @@
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
     "@typescript/server-harness": "^0.2.0",
-    "babel-jest": "^29.0.3",
     "dedent": "^0.7.0",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ specifiers:
   '@jest/types': ^29.0.3
   '@mizdra/eslint-config-mizdra': ^1.2.0
   '@mizdra/prettier-config-mizdra': ^1.0.0
+  '@swc/core': ^1.3.8
+  '@swc/jest': ^0.2.23
   '@types/babel__core': ^7.1.19
   '@types/dedent': ^0.7.0
   '@types/glob': ^7.2.0
@@ -77,6 +79,8 @@ devDependencies:
   '@jest/types': 29.0.3
   '@mizdra/eslint-config-mizdra': 1.2.0_lnvtiryhdvdxorfh3ypdueoimi
   '@mizdra/prettier-config-mizdra': 1.0.0_prettier@2.7.1
+  '@swc/core': 1.3.8
+  '@swc/jest': 0.2.23_@swc+core@1.3.8
   '@types/babel__core': 7.1.19
   '@types/dedent': 0.7.0
   '@types/glob': 7.2.0
@@ -658,6 +662,13 @@ packages:
       - ts-node
     dev: true
 
+  /@jest/create-cache-key-function/27.5.1:
+    resolution: {integrity: sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.5.1
+    dev: true
+
   /@jest/environment/29.0.3:
     resolution: {integrity: sha512-iKl272NKxYNQNqXMQandAIwjhQaGw5uJfGXduu8dS9llHi8jV2ChWrtOAVPnMbaaoDhnI3wgUGNDvZgHeEJQCA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -813,6 +824,17 @@ packages:
       - supports-color
     dev: true
 
+  /@jest/types/27.5.1:
+    resolution: {integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.7.11
+      '@types/yargs': 16.0.4
+      chalk: 4.1.2
+    dev: true
+
   /@jest/types/29.0.3:
     resolution: {integrity: sha512-coBJmOQvurXjN1Hh5PzF7cmsod0zLIOXpP8KD161mqNlroMhLcwpODiEzi7ZsRl5Z/AIuxpeNm8DCl43F4kz8A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -946,6 +968,179 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: true
 
+  /@swc/core-android-arm-eabi/1.3.8:
+    resolution: {integrity: sha512-7SKRmfT21Iwy1UJVirS89KO1YqA/nYeG6Te97Vi50e0Ua1XmmogE+ooUg4CNk0wevtVmgB3AHXK/1/ak6qY/Ag==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      '@swc/wasm': 1.2.122
+    dev: true
+    optional: true
+
+  /@swc/core-android-arm64/1.3.8:
+    resolution: {integrity: sha512-K7PwYMOukAFUWR1f1xukNhQXpCWjYfOnBA130hdovuW7J+cxYX2O8L5cKW+VOmlTNXU561+k0jNSO5NkJ4pSSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      '@swc/wasm': 1.2.130
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-arm64/1.3.8:
+    resolution: {integrity: sha512-sEynC48HWwYQ2RzJxBejnWfRQkl65f1+fWNjSWqAIii7I+fJT5La98hJrg+5dfZROBs34g1Zxt8+2Gttm25Nmg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64/1.3.8:
+    resolution: {integrity: sha512-yimEqFZpmXU6uTnSw1A6umKBN1B68I+Cbl/q4IHm3Z3B9a/aymiQ7lJNrYYEHOgfpHLka4SWwvdSBSrpMczDfg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-freebsd-x64/1.3.8:
+    resolution: {integrity: sha512-kGGDDrKVCoM2A8lAJ3jFiWuafxtFxMmvkGlo72GikZsFDHibqr2K2+Ur++nwOz/ZFOf1HJwEbYVbbDa84pSlCw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dependencies:
+      '@swc/wasm': 1.2.130
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf/1.3.8:
+    resolution: {integrity: sha512-kLpA6Oei9J7u7NBFT80ziAe3cLhOV7vo/Li9rV44AI8iU6df7KXt7hvzmTyh5gXOg3f98wcMOakFF1FsKvSSdA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dependencies:
+      '@swc/wasm': 1.2.130
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu/1.3.8:
+    resolution: {integrity: sha512-5W1sAM1lNmDfMy8DzRUiyjubDPZVIvzQRhdsP1zCDE/JKYaDJG8BzeSE6J3VdxNyLfe6tFvJTOCTyNAGWJBiTA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl/1.3.8:
+    resolution: {integrity: sha512-xdmZX44xzjdG4zqIWEqkZVWukhw1lwVVLjXiQt94GZ9RISpUvanydIzahB/iuI/2/eWP4Stf6vyXn66ay1jIcA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu/1.3.8:
+    resolution: {integrity: sha512-37YyUxXgLfiILzfoIkbfEB4mRJfWutaY9OThi9H1hLYaXLTfdWkk7bksALK473NY6/Vi/TrjYi1cz+GSteR/nw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl/1.3.8:
+    resolution: {integrity: sha512-/MhCGWlIu2rjvUuGKNZSTLUm1jDus2ggmaZpbq87QSA8otPyKB4k5t6ySUzuSTRL8Qk/bLy1xjtjAv2sOzwzJA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc/1.3.8:
+    resolution: {integrity: sha512-UF4BoOtmquKSt5eIODvrimqLLTG30vuIvY8z1/3RJyzCI3uZE3csetmAMvry8ioS1vC5DFETNh4xFO20CJvR0g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dependencies:
+      '@swc/wasm': 1.2.130
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc/1.3.8:
+    resolution: {integrity: sha512-ZsLm+Gimv8RO77AQjkaqs4jncw7AmR5HgR+I6gSRsVhLEo3tRbzSK2br98PRC217RA86Ei148/WUutu9IA7/5g==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dependencies:
+      '@swc/wasm': 1.2.130
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc/1.3.8:
+    resolution: {integrity: sha512-7Kxx6K4hEbwjj3IyD5hqoUGbOtuYJoMUh6ac+gce22oxq4sWWkVRbV0s+oJSXqWA0/PCu07t0m1/B4Z0MpqwuA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core/1.3.8:
+    resolution: {integrity: sha512-EEinXtV7MvzWt1dgqnkfUaxCwPnSo3ZeWQzTpppCZFkM9hn+kfViTig2aS1aoXvwi/SsDZ51DDs4st8xr4yqhQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@swc/core-android-arm-eabi': 1.3.8
+      '@swc/core-android-arm64': 1.3.8
+      '@swc/core-darwin-arm64': 1.3.8
+      '@swc/core-darwin-x64': 1.3.8
+      '@swc/core-freebsd-x64': 1.3.8
+      '@swc/core-linux-arm-gnueabihf': 1.3.8
+      '@swc/core-linux-arm64-gnu': 1.3.8
+      '@swc/core-linux-arm64-musl': 1.3.8
+      '@swc/core-linux-x64-gnu': 1.3.8
+      '@swc/core-linux-x64-musl': 1.3.8
+      '@swc/core-win32-arm64-msvc': 1.3.8
+      '@swc/core-win32-ia32-msvc': 1.3.8
+      '@swc/core-win32-x64-msvc': 1.3.8
+    dev: true
+
+  /@swc/jest/0.2.23_@swc+core@1.3.8:
+    resolution: {integrity: sha512-ZLj17XjHbPtNsgqjm83qizENw05emLkKGu3WuPUttcy9hkngl0/kcc7fDbcSBpADS0GUtsO+iKPjZFWVAtJSlA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+    dependencies:
+      '@jest/create-cache-key-function': 27.5.1
+      '@swc/core': 1.3.8
+      jsonc-parser: 3.2.0
+    dev: true
+
+  /@swc/wasm/1.2.122:
+    resolution: {integrity: sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/wasm/1.2.130:
+    resolution: {integrity: sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@types/babel__core/7.1.19:
     resolution: {integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==}
     dependencies:
@@ -1053,6 +1248,12 @@ packages:
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+    dev: true
+
+  /@types/yargs/16.0.4:
+    resolution: {integrity: sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==}
+    dependencies:
+      '@types/yargs-parser': 21.0.0
     dev: true
 
   /@types/yargs/17.0.13:
@@ -3067,6 +3268,10 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
+    dev: true
+
+  /jsonc-parser/3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
   /kleur/3.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,12 @@ patchedDependencies:
     path: patches/postcss-load-config@4.0.1.patch
 
 specifiers:
-  '@babel/core': ^7.18.13
-  '@babel/preset-typescript': ^7.18.6
   '@jest/globals': ^29.0.3
   '@jest/types': ^29.0.3
   '@mizdra/eslint-config-mizdra': ^1.2.0
   '@mizdra/prettier-config-mizdra': ^1.0.0
   '@swc/core': ^1.3.8
   '@swc/jest': ^0.2.23
-  '@types/babel__core': ^7.1.19
   '@types/dedent': ^0.7.0
   '@types/glob': ^7.2.0
   '@types/jest': ^29.0.0
@@ -26,7 +23,6 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ^5.31.0
   '@typescript-eslint/parser': ^5.31.0
   '@typescript/server-harness': ^0.2.0
-  babel-jest: ^29.0.3
   camelcase: ^7.0.0
   chalk: ^5.0.1
   chokidar: ^3.5.3
@@ -73,15 +69,12 @@ dependencies:
   yargs: 17.5.1
 
 devDependencies:
-  '@babel/core': 7.18.13
-  '@babel/preset-typescript': 7.18.6_@babel+core@7.18.13
   '@jest/globals': 29.0.3
   '@jest/types': 29.0.3
   '@mizdra/eslint-config-mizdra': 1.2.0_lnvtiryhdvdxorfh3ypdueoimi
   '@mizdra/prettier-config-mizdra': 1.0.0_prettier@2.7.1
   '@swc/core': 1.3.8
   '@swc/jest': 0.2.23_@swc+core@1.3.8
-  '@types/babel__core': 7.1.19
   '@types/dedent': 0.7.0
   '@types/glob': 7.2.0
   '@types/jest': 29.0.0
@@ -93,7 +86,6 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 5.31.0_d5zwcxr4bwkhmuo464cb3a2puu
   '@typescript-eslint/parser': 5.31.0_he2ccbldppg44uulnyq4rwocfa
   '@typescript/server-harness': 0.2.0
-  babel-jest: 29.0.3_@babel+core@7.18.13
   dedent: 0.7.0
   eslint: 8.20.0
   eslint-config-prettier: 8.5.0_eslint@8.20.0
@@ -163,13 +155,6 @@ packages:
       jsesc: 2.5.2
     dev: true
 
-  /@babel/helper-annotate-as-pure/7.18.6:
-    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.8
-    dev: true
-
   /@babel/helper-compilation-targets/7.18.9_@babel+core@7.18.13:
     resolution: {integrity: sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==}
     engines: {node: '>=6.9.0'}
@@ -181,24 +166,6 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.2
       semver: 6.3.0
-    dev: true
-
-  /@babel/helper-create-class-features-plugin/7.18.13_@babel+core@7.18.13:
-    resolution: {integrity: sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.18.9
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helper-environment-visitor/7.18.9:
@@ -216,13 +183,6 @@ packages:
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.13
-    dev: true
-
-  /@babel/helper-member-expression-to-functions/7.18.9:
-    resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.13
@@ -251,13 +211,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.18.6:
-    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.8
-    dev: true
-
   /@babel/helper-plugin-utils/7.18.6:
     resolution: {integrity: sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==}
     engines: {node: '>=6.9.0'}
@@ -266,19 +219,6 @@ packages:
   /@babel/helper-plugin-utils/7.18.9:
     resolution: {integrity: sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-replace-supers/7.18.9:
-    resolution: {integrity: sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.18.9
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.18.13
-      '@babel/types': 7.18.13
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helper-simple-access/7.18.6:
@@ -473,34 +413,6 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.18.6
-    dev: true
-
-  /@babel/plugin-transform-typescript/7.18.12_@babel+core@7.18.13:
-    resolution: {integrity: sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-create-class-features-plugin': 7.18.13_@babel+core@7.18.13
-      '@babel/helper-plugin-utils': 7.18.9
-      '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.13
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/preset-typescript/7.18.6_@babel+core@7.18.13:
-    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.18.6
-      '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.18.12_@babel+core@7.18.13
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/template/7.18.10:


### PR DESCRIPTION
This has resulted in 1.3 times faster test execution time.

## before

https://github.com/mizdra/happy-css-modules/actions/runs/3258428731/jobs/5350504376
```
> NODE_OPTIONS="--experimental-vm-modules $NODE_OPTIONS" jest

(node:1790) ExperimentalWarning: VM Modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
PASS src/loader/postcss.test.ts
PASS src/loader/index.test.ts
PASS src/integration-test/go-to-definition.test.ts
PASS src/emitter/dts.test.ts
PASS src/runner.test.ts
PASS src/resolver/webpack-resolver.test.ts
PASS src/transformer/postcss-transformer.test.ts
PASS src/emitter/index.test.ts
PASS src/transformer/scss-transformer.test.ts
PASS src/transformer/less-transformer.test.ts
PASS src/cli.test.ts
PASS src/util.test.ts
PASS src/transformer/index.test.ts
PASS src/emitter/file-system.test.ts
PASS src/resolver/node-resolver.test.ts
PASS src/emitter/source-map.test.ts
PASS src/resolver/relative-resolver.test.ts
PASS src/resolver/index.test.ts

Test Suites: 18 passed, 18 total
Tests:       1 todo, 102 passed, 103 total
Snapshots:   56 passed, 56 total
Time:        16.79 s
Ran all test suites.
```

## after
https://github.com/mizdra/happy-css-modules/actions/runs/3258450139/jobs/5350541010
```
> NODE_OPTIONS="--experimental-vm-modules $NODE_OPTIONS" jest

(node:1813) ExperimentalWarning: VM Modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
PASS src/loader/postcss.test.ts
PASS src/loader/index.test.ts
PASS src/integration-test/go-to-definition.test.ts
PASS src/emitter/dts.test.ts
PASS src/runner.test.ts
PASS src/resolver/webpack-resolver.test.ts
PASS src/transformer/postcss-transformer.test.ts
PASS src/emitter/index.test.ts
PASS src/transformer/scss-transformer.test.ts
PASS src/transformer/less-transformer.test.ts
PASS src/cli.test.ts
PASS src/util.test.ts
PASS src/transformer/index.test.ts
PASS src/emitter/file-system.test.ts
PASS src/resolver/node-resolver.test.ts
PASS src/emitter/source-map.test.ts
PASS src/resolver/relative-resolver.test.ts
PASS src/resolver/index.test.ts

Test Suites: 18 passed, 18 total
Tests:       1 todo, 102 passed, 103 total
Snapshots:   56 passed, 56 total
Time:        12.002 s
Ran all test suites.
```