### PR TITLE
Remove `--outDir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Generate .d.ts and .d.ts.map for CSS modules.
 hcm [options] <glob>
 
 Options:
-      --outDir               Output directory                                                                                       [string]
   -w, --watch                Watch input directory's css files or pattern                                         [boolean] [default: false]
       --localsConvention     Style of exported class names.                  [choices: "camelCase", "camelCaseOnly", "dashes", "dashesOnly"]
       --declarationMap       Create sourcemaps for d.ts files                                                      [boolean] [default: true]

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -10,10 +10,6 @@ describe('parseArgv', () => {
     // TODO: Support multiple patterns
     // parseArgv([...baseArgs, 'foo', 'bar']);
   });
-  test('--outDir', () => {
-    expect(parseArgv([...baseArgs, '1.css', '--outDir', 'foo']).outDir).toStrictEqual('foo');
-    expect(parseArgv([...baseArgs, '1.css', '--outDir', '1']).outDir).toStrictEqual('1');
-  });
   test('--watch', () => {
     expect(parseArgv([...baseArgs, '1.css', '--watch']).watch).toBe(true);
     expect(parseArgv([...baseArgs, '1.css', '--no-watch']).watch).toBe(false);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,10 +22,6 @@ export function parseArgv(argv: string[]): RunnerOptions {
     .example('$0 \'src/**/*.module.css\' --webpackResolveAlias=\'{"@": "src"}\'', "Run with webpack's `resolve.alias`.")
     .example("$0 'src/**/*.module.css' --cache=false", 'Disable cache.')
     .detectLocale(false)
-    .option('outDir', {
-      type: 'string',
-      describe: 'Output directory',
-    })
     .option('watch', {
       type: 'boolean',
       alias: 'w',
@@ -103,7 +99,6 @@ export function parseArgv(argv: string[]): RunnerOptions {
   const patterns: string[] = parsedArgv._.map((pattern) => pattern.toString());
   return {
     pattern: patterns[0]!,
-    outDir: parsedArgv.outDir,
     watch: parsedArgv.watch,
     localsConvention: parsedArgv.localsConvention,
     declarationMap: parsedArgv.declarationMap,

--- a/src/emitter/dts.test.ts
+++ b/src/emitter/dts.test.ts
@@ -9,12 +9,7 @@ const loader = new Loader();
 const isExternalFile = () => false;
 
 test('getDtsFilePath', () => {
-  expect(getDtsFilePath('/app/src/dir/1.css', undefined)).toBe('/app/src/dir/1.css.d.ts');
-  expect(getDtsFilePath('/app/src/dir/1.css', { rootDir: '/app', outDir: '/app/dist' })).toBe(
-    '/app/dist/src/dir/1.css.d.ts',
-  );
-  expect(() => getDtsFilePath('/tmp/src/dir/1.css', { rootDir: '/app', outDir: '/app/dist' })).toThrow();
-  expect(() => getDtsFilePath('/app/src/dir/1.css', { rootDir: '/app', outDir: '/tmp/dist' })).toThrow();
+  expect(getDtsFilePath('/app/src/dir/1.css')).toBe('/app/src/dir/1.css.d.ts');
 });
 
 describe('generateDtsContentWithSourceMap', () => {

--- a/src/emitter/dts.ts
+++ b/src/emitter/dts.ts
@@ -1,27 +1,18 @@
 import { EOL } from 'os';
-import { join, relative, basename } from 'path';
+import { basename } from 'path';
 import camelcase from 'camelcase';
 import { SourceNode, type CodeWithSourceMap } from '../library/source-map/index.js';
 import { type Token } from '../loader/index.js';
 import { type LocalsConvention } from '../runner.js';
-import { type DistOptions, getRelativePath, isSubDirectoryFile, type DtsFormatOptions } from './index.js';
+import { getRelativePath, type DtsFormatOptions } from './index.js';
 
 /**
  * Get .d.ts file path.
  * @param filePath The path to the source file (i.e. `/dir/foo.css`). It is absolute.
- * @param distOptions The distribution option.
  * @returns The path to the .d.ts file. It is absolute.
  */
-export function getDtsFilePath(filePath: string, distOptions: DistOptions | undefined): string {
-  if (distOptions) {
-    if (!isSubDirectoryFile(distOptions.rootDir, filePath))
-      throw new Error(`The filePath(${filePath}) is not a subdirectory of rootDir(${distOptions.rootDir}).`);
-    if (!isSubDirectoryFile(distOptions.rootDir, distOptions.outDir))
-      throw new Error(`The outDir(${distOptions.outDir}) is not a subdirectory of rootDir(${distOptions.rootDir}).`);
-    return join(distOptions.outDir, relative(distOptions.rootDir, filePath) + '.d.ts');
-  } else {
-    return filePath + '.d.ts';
-  }
+export function getDtsFilePath(filePath: string): string {
+  return filePath + '.d.ts';
 }
 
 function dashesCamelCase(str: string): string {

--- a/src/emitter/index.test.ts
+++ b/src/emitter/index.test.ts
@@ -26,7 +26,6 @@ describe('emitGeneratedFiles', () => {
   const defaultArgs = {
     filePath: getFixturePath('/test/1.css'),
     tokens: [fakeToken({ name: 'foo', originalLocations: [{ start: { line: 1, column: 1 } }] })],
-    distOptions: undefined,
     emitDeclarationMap: true,
     dtsFormatOptions: undefined,
     cwd: getFixturePath('/test'),

--- a/src/emitter/index.ts
+++ b/src/emitter/index.ts
@@ -19,14 +19,6 @@ export function isSubDirectoryFile(fromDirectory: string, toFilePath: string): b
   return isAbsolute(toFilePath) && toFilePath.startsWith(fromDirectory);
 }
 
-/** The distribution option. */
-export type DistOptions = {
-  /** Root directory. It is absolute. */
-  rootDir: string;
-  /** The path to the output directory. It is absolute. */
-  outDir: string;
-};
-
 export type DtsFormatOptions = {
   localsConvention?: LocalsConvention;
 };
@@ -37,8 +29,6 @@ export type EmitterOptions = {
   filePath: string;
   /** The tokens exported by the source file. */
   tokens: Token[];
-  /** The distribution option. */
-  distOptions: DistOptions | undefined;
   /** Whether to output declaration map (i.e. `/dir/foo.css.d.ts.map`) or not. */
   emitDeclarationMap: boolean | undefined;
   /** The options for formatting the type definition. */
@@ -50,13 +40,12 @@ export type EmitterOptions = {
 export async function emitGeneratedFiles({
   filePath,
   tokens,
-  distOptions,
   emitDeclarationMap,
   dtsFormatOptions,
   isExternalFile,
 }: EmitterOptions): Promise<void> {
-  const dtsFilePath = getDtsFilePath(filePath, distOptions);
-  const sourceMapFilePath = getSourceMapFilePath(filePath, distOptions);
+  const dtsFilePath = getDtsFilePath(filePath);
+  const sourceMapFilePath = getSourceMapFilePath(filePath);
   const { dtsContent, sourceMap } = generateDtsContentWithSourceMap(
     filePath,
     dtsFilePath,
@@ -82,11 +71,10 @@ export async function emitGeneratedFiles({
  */
 export async function isGeneratedFilesExist(
   filePath: string,
-  distOptions: DistOptions | undefined,
   emitDeclarationMap: boolean | undefined,
 ): Promise<boolean> {
-  const dtsFilePath = getDtsFilePath(filePath, distOptions);
-  const sourceMapFilePath = getSourceMapFilePath(filePath, distOptions);
+  const dtsFilePath = getDtsFilePath(filePath);
+  const sourceMapFilePath = getSourceMapFilePath(filePath);
   if (emitDeclarationMap && !(await exists(sourceMapFilePath))) {
     return false;
   }

--- a/src/emitter/source-map.test.ts
+++ b/src/emitter/source-map.test.ts
@@ -2,12 +2,7 @@ import { EOL } from 'os';
 import { getSourceMapFilePath, generateSourceMappingURLComment } from './source-map.js';
 
 test('getSourceMapFilePath', () => {
-  expect(getSourceMapFilePath('/app/src/dir/1.css', undefined)).toBe('/app/src/dir/1.css.d.ts.map');
-  expect(getSourceMapFilePath('/app/src/dir/1.css', { rootDir: '/app', outDir: '/app/dist' })).toBe(
-    '/app/dist/src/dir/1.css.d.ts.map',
-  );
-  expect(() => getSourceMapFilePath('/tmp/src/dir/1.css', { rootDir: '/app', outDir: '/app/dist' })).toThrow();
-  expect(() => getSourceMapFilePath('/app/src/dir/1.css', { rootDir: '/app', outDir: '/tmp/dist' })).toThrow();
+  expect(getSourceMapFilePath('/app/src/dir/1.css')).toBe('/app/src/dir/1.css.d.ts.map');
 });
 
 test('generateSourceMappingURLComment', () => {

--- a/src/emitter/source-map.ts
+++ b/src/emitter/source-map.ts
@@ -1,15 +1,14 @@
 import { EOL } from 'os';
 import { getDtsFilePath } from './dts.js';
-import { type DistOptions, getRelativePath } from './index.js';
+import { getRelativePath } from './index.js';
 
 /**
  * Get .d.ts.map file path.
  * @param filePath The path to the source file (i.e. `foo.css`). It is absolute.
- * @param distOptions The distribution option.
  * @returns The path to the .d.ts.map file. It is absolute.
  */
-export function getSourceMapFilePath(filePath: string, distOptions: DistOptions | undefined): string {
-  return getDtsFilePath(filePath, distOptions) + '.map';
+export function getSourceMapFilePath(filePath: string): string {
+  return getDtsFilePath(filePath) + '.map';
 }
 
 export function generateSourceMappingURLComment(dtsFilePath: string, sourceMapFilePath: string): string {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -23,7 +23,6 @@ export type LocalsConvention = 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashe
 
 export interface RunnerOptions {
   pattern: string;
-  outDir?: string | undefined;
   watch?: boolean | undefined;
   localsConvention?: LocalsConvention | undefined;
   declarationMap?: boolean | undefined;
@@ -94,12 +93,6 @@ export async function run(options: RunnerOptions): Promise<Watcher | void> {
       webpackResolveAlias: options.webpackResolveAlias,
     });
   const transformer = options.transformer ?? createDefaultTransformer({ cwd, postcssConfig: options.postcssConfig });
-  const distOptions = options.outDir
-    ? {
-        rootDir: cwd, // TODO: support `--rootDir` option
-        outDir: options.outDir,
-      }
-    : undefined;
 
   const installedPeerDependencies = await getInstalledPeerDependencies();
   const cache = await createCache({
@@ -124,7 +117,6 @@ export async function run(options: RunnerOptions): Promise<Watcher | void> {
       await emitGeneratedFiles({
         filePath,
         tokens: result.tokens,
-        distOptions,
         emitDeclarationMap: options.declarationMap,
         dtsFormatOptions: {
           localsConvention: options.localsConvention,
@@ -169,7 +161,7 @@ export async function run(options: RunnerOptions): Promise<Watcher | void> {
     const errors: unknown[] = [];
     for (const filePath of filePaths) {
       try {
-        const _isGeneratedFilesExist = await isGeneratedFilesExist(filePath, distOptions, options.declarationMap);
+        const _isGeneratedFilesExist = await isGeneratedFilesExist(filePath, options.declarationMap);
         const _isChangedFile = await isChangedFile(filePath);
         // Generate .d.ts and .d.ts.map only when the file has been updated.
         // However, if .d.ts or .d.ts.map has not yet been generated, always generate.


### PR DESCRIPTION
At this time the option is defined but not implemented.

Perhaps it is possible to implement it. However, my guess is that updating `tsc` could break that functionality. I don't think this option should be implemented.