### PR TITLE
Add missing README

### DIFF
--- a/packages/happy-css-modules/README.md
+++ b/packages/happy-css-modules/README.md
@@ -1,0 +1,17 @@
+<p align="center">
+  <img alt="Cover image" src="./docs/cover.svg" />
+</p>
+
+<h2 align="center">Happy CSS Modules</h2>
+
+<p align="center">
+  <em>Typed, definition jumpable CSS Modules.</em>
+  <br />
+  <em>Moreover, easy!</em>
+</p>
+
+https://user-images.githubusercontent.com/9639995/189538880-872ad38d-2c9d-4c19-b257-521018963eec.mov
+
+## Usage
+
+See [https://github.com/mizdra/happy-css-modules].


### PR DESCRIPTION
Fix an issue where the README does not display on npmjs.com.

https://www.npmjs.com/package/happy-css-modules
<img width="1233" alt="image" src="https://github.com/mizdra/happy-css-modules/assets/9639995/4b8a453f-9a5c-4380-ba39-819c12b04053">
