### PR TITLE
Require `sass@1.63.3+`

### DIFF
--- a/packages/happy-css-modules/package.json
+++ b/packages/happy-css-modules/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "less": "^3.0.0 || ^4.0.0",
     "postcss": "^8.0.0",
-    "sass": "^1.0.0"
+    "sass": "^1.63.3"
   },
   "peerDependenciesMeta": {
     "sass": {

--- a/packages/happy-css-modules/src/transformer/scss-transformer.ts
+++ b/packages/happy-css-modules/src/transformer/scss-transformer.ts
@@ -22,8 +22,8 @@ function promisifySassRender(sass: typeof import('sass')) {
 export const createScssTransformer: () => Transformer = () => {
   let sass: typeof import('sass');
   return async (source, options) => {
-    const sassModule = await import('sass').catch(handleImportError('sass'));
-    sass ??= sassModule.default ?? sassModule;
+    // eslint-disable-next-line require-atomic-updates
+    sass ??= await import('sass').catch(handleImportError('sass'));
     const render = promisifySassRender(sass);
     const result = await render({
       data: source,


### PR DESCRIPTION
Bump the lowest version of sass to suppress the warning added by `sass@1.63.4`.

https://github.com/sass/dart-sass/releases/tag/1.63.4