### PR TITLE
Tokens loaded by `composes` are not exported

### DIFF
--- a/packages/example/03-composes/1.css.d.ts
+++ b/packages/example/03-composes/1.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles:
   & Readonly<{ "a": string }>
-  & Readonly<Pick<(typeof import("./2.css"))["default"], "b">>
 ;
 export default styles;
 //# sourceMappingURL=./1.css.d.ts.map

--- a/packages/example/03-composes/1.css.d.ts.map
+++ b/packages/example/03-composes/1.css.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["./1.css"],"names":["a"],"mappings":"AAAA;AAAA,E,aAAAA,G,WAAA;AAAA,E,4DAAA;AAAA;AAAA","file":"1.css.d.ts","sourceRoot":""}
+{"version":3,"sources":["./1.css"],"names":["a"],"mappings":"AAAA;AAAA,E,aAAAA,G,WAAA;AAAA;AAAA","file":"1.css.d.ts","sourceRoot":""}

--- a/packages/example/03-composes/2.css.d.ts
+++ b/packages/example/03-composes/2.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles:
   & Readonly<{ "b": string }>
-  & Readonly<Pick<(typeof import("./3.css"))["default"], "c">>
 ;
 export default styles;
 //# sourceMappingURL=./2.css.d.ts.map

--- a/packages/example/03-composes/2.css.d.ts.map
+++ b/packages/example/03-composes/2.css.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["./2.css"],"names":["b"],"mappings":"AAAA;AAAA,E,aAAAA,G,WAAA;AAAA,E,4DAAA;AAAA;AAAA","file":"2.css.d.ts","sourceRoot":""}
+{"version":3,"sources":["./2.css"],"names":["b"],"mappings":"AAAA;AAAA,E,aAAAA,G,WAAA;AAAA;AAAA","file":"2.css.d.ts","sourceRoot":""}

--- a/packages/example/04-sass/1.scss.d.ts
+++ b/packages/example/04-sass/1.scss.d.ts
@@ -6,7 +6,6 @@ declare const styles:
   & Readonly<{ "a_2": string }>
   & Readonly<{ "a_2_1": string }>
   & Readonly<{ "a_2_2": string }>
-  & Readonly<Pick<(typeof import("./4.scss"))["default"], "d">>
 ;
 export default styles;
 //# sourceMappingURL=./1.scss.d.ts.map

--- a/packages/example/04-sass/1.scss.d.ts.map
+++ b/packages/example/04-sass/1.scss.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["./1.scss"],"names":["a_1","a_2","a_2_1","a_2_2"],"mappings":"AAAA;AAAA,E,+DAAA;AAAA,E,6DAAA;AAAA,E,aAGAA,K,WAHA;AAAA,E,aAMAC,K,WANA;AAAA,E,aASEA,K,WATF;AAAA,E,aASEC,O,WATF;AAAA,E,aAYEC,O,WAZF;AAAA,E,6DAAA;AAAA;AAAA","file":"1.scss.d.ts","sourceRoot":""}
+{"version":3,"sources":["./1.scss"],"names":["a_1","a_2","a_2_1","a_2_2"],"mappings":"AAAA;AAAA,E,+DAAA;AAAA,E,6DAAA;AAAA,E,aAGAA,K,WAHA;AAAA,E,aAMAC,K,WANA;AAAA,E,aASEA,K,WATF;AAAA,E,aASEC,O,WATF;AAAA,E,aAYEC,O,WAZF;AAAA;AAAA","file":"1.scss.d.ts","sourceRoot":""}

--- a/packages/example/05-less/1.less.d.ts
+++ b/packages/example/05-less/1.less.d.ts
@@ -4,7 +4,6 @@ declare const styles:
   & Readonly<{ "a_2": string }>
   & Readonly<{ "a_2_1": string }>
   & Readonly<{ "a_2_2": string }>
-  & Readonly<Pick<(typeof import("./3.less"))["default"], "c">>
 ;
 export default styles;
 //# sourceMappingURL=./1.less.d.ts.map

--- a/packages/example/05-less/1.less.d.ts.map
+++ b/packages/example/05-less/1.less.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["./1.less"],"names":["a_1","a_2","a_2_1","a_2_2"],"mappings":"AAAA;AAAA,E,+DAAA;AAAA,E,aAEAA,K,WAFA;AAAA,E,aAKAC,K,WALA;AAAA,E,aAQEC,O,WARF;AAAA,E,aAWEC,O,WAXF;AAAA,E,6DAAA;AAAA;AAAA","file":"1.less.d.ts","sourceRoot":""}
+{"version":3,"sources":["./1.less"],"names":["a_1","a_2","a_2_1","a_2_2"],"mappings":"AAAA;AAAA,E,+DAAA;AAAA,E,aAEAA,K,WAFA;AAAA,E,aAKAC,K,WALA;AAAA,E,aAQEC,O,WARF;AAAA,E,aAWEC,O,WAXF;AAAA;AAAA","file":"1.less.d.ts","sourceRoot":""}

--- a/packages/example/app.ts
+++ b/packages/example/app.ts
@@ -29,8 +29,6 @@ console.log(styles2.a);
 console.log(styles2.b);
 
 console.log(styles3.a);
-console.log(styles3.b);
-// console.log(styles3.c); // Maybe it needs fixing?
 
 console.log(styles4.a_1);
 console.log(styles4.a_2);
@@ -38,14 +36,12 @@ console.log(styles4.a_2_1);
 console.log(styles4.a_2_2);
 console.log(styles4.b_1);
 console.log(styles4.c);
-console.log(styles4.d);
 
 console.log(styles5.a_1);
 console.log(styles5.a_2);
 console.log(styles5.a_2_1);
 console.log(styles5.a_2_2);
 console.log(styles5.b_1);
-console.log(styles5.c);
 
 console.log(styles6.a_1);
 console.log(styles6.a_2);

--- a/packages/happy-css-modules/src/integration-test/go-to-definition.test.ts
+++ b/packages/happy-css-modules/src/integration-test/go-to-definition.test.ts
@@ -365,9 +365,7 @@ test('with transformer', async () => {
         "identifier": "c",
       },
       {
-        "definitions": [
-          { file: "<fixtures>/test/4.scss", text: ".d ", start: { line: 1, offset: 1 }, end: { line: 1, offset: 4 } },
-        ],
+        "definitions": [],
         "identifier": "d",
       },
     ]

--- a/packages/happy-css-modules/src/locator/index.test.ts
+++ b/packages/happy-css-modules/src/locator/index.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { jest } from '@jest/globals';
 import dedent from 'dedent';
 import { createDefaultTransformer } from '../index.js';
-import { createFixtures, FIXTURE_DIR_PATH, getFixturePath } from '../test-util/util.js';
+import { createFixtures, getFixturePath } from '../test-util/util.js';
 import { sleepSync } from '../util.js';
 
 const readFileSpy = jest.spyOn(fs, 'readFile');
@@ -140,36 +140,12 @@ test('tracks other files when `composes` is present', async () => {
   const result = await locator.load(getFixturePath('/test/1.css'));
   expect(result).toMatchInlineSnapshot(`
     {
-      dependencies: ["<fixtures>/test/2.css", "<fixtures>/test/3.css", "<fixtures>/test/4.css"],
+      dependencies: [],
       tokens: [
         {
           name: "a",
           originalLocations: [
             { filePath: "<fixtures>/test/1.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
-        },
-        {
-          name: "b",
-          originalLocations: [
-            { filePath: "<fixtures>/test/2.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
-        },
-        {
-          name: "c",
-          originalLocations: [
-            { filePath: "<fixtures>/test/3.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
-        },
-        {
-          name: "d",
-          originalLocations: [
-            { filePath: "<fixtures>/test/3.css", start: { line: 2, column: 1 }, end: { line: 2, column: 2 } },
-          ],
-        },
-        {
-          name: "e",
-          originalLocations: [
-            { filePath: "<fixtures>/test/4.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
           ],
         },
       ],
@@ -204,7 +180,7 @@ test('normalizes tokens', async () => {
   const result = await locator.load(getFixturePath('/test/1.css'));
   expect(result).toMatchInlineSnapshot(`
     {
-      dependencies: ["<fixtures>/test/2.css", "<fixtures>/test/3.css"],
+      dependencies: ["<fixtures>/test/2.css"],
       tokens: [
         {
           name: "a",
@@ -218,12 +194,6 @@ test('normalizes tokens', async () => {
           name: "b",
           originalLocations: [
             { filePath: "<fixtures>/test/2.css", start: { line: 2, column: 1 }, end: { line: 2, column: 2 } },
-          ],
-        },
-        {
-          name: "c",
-          originalLocations: [
-            { filePath: "<fixtures>/test/3.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
           ],
         },
       ],
@@ -292,25 +262,7 @@ test('ignores the composition of non-existent tokens', async () => {
     `,
   });
   const result = await locator.load(getFixturePath('/test/1.css'));
-  expect(result.tokens.map((t) => t.name)).toStrictEqual(['a', 'b']);
-});
-
-test('throws error the composition of non-existent file', async () => {
-  // In postcss-modules, compositions of non-existent file are causes an error.
-  // Therefore, happy-css-modules follows suit.
-  createFixtures({
-    '/test/1.css': dedent`
-    .a {
-      composes: a from './2.css';
-    }
-    `,
-  });
-  await expect(async () => {
-    await locator.load(getFixturePath('/test/1.css')).catch((e) => {
-      e.message = e.message.replace(FIXTURE_DIR_PATH, '<fixtures>');
-      throw e;
-    });
-  }).rejects.toThrowError(`Could not resolve './2.css' in '<fixtures>/test/1.css'`);
+  expect(result.tokens.map((t) => t.name)).toStrictEqual(['a']);
 });
 
 describe('supports sourcemap', () => {

--- a/packages/happy-css-modules/src/test-util/util.ts
+++ b/packages/happy-css-modules/src/test-util/util.ts
@@ -2,7 +2,7 @@ import { constants, mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { access } from 'fs/promises';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
-import postcss, { type Root, type Rule, type AtRule, type Declaration } from 'postcss';
+import postcss, { type Root, type Rule, type AtRule } from 'postcss';
 import { type ClassName } from 'postcss-selector-parser';
 import { type Token, collectNodes, type Location } from '../locator/index.js';
 import { sleepSync } from '../util.js';
@@ -23,10 +23,6 @@ export function createAtImports(root: Root): AtRule[] {
 
 export function createClassSelectors(root: Root): { rule: Rule; classSelector: ClassName }[] {
   return collectNodes(root).classSelectors;
-}
-
-export function createComposesDeclarations(root: Root): Declaration[] {
-  return collectNodes(root).composesDeclarations;
 }
 
 export function fakeToken(args: {

--- a/packages/happy-css-modules/src/transformer/less-transformer.test.ts
+++ b/packages/happy-css-modules/src/transformer/less-transformer.test.ts
@@ -40,7 +40,7 @@ test('handles less features', async () => {
   // FIXME: The end position of 'a_2_2' is incorrect.
   expect(result).toMatchInlineSnapshot(`
     {
-      dependencies: ["<fixtures>/test/2.less", "<fixtures>/test/3.less"],
+      dependencies: ["<fixtures>/test/2.less"],
       tokens: [
         {
           name: "b_1",
@@ -70,12 +70,6 @@ test('handles less features', async () => {
           name: "a_2_2",
           originalLocations: [
             { filePath: "<fixtures>/test/1.less", start: { line: 7, column: 3 }, end: { line: 7, column: 8 } },
-          ],
-        },
-        {
-          name: "c",
-          originalLocations: [
-            { filePath: "<fixtures>/test/3.less", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
           ],
         },
       ],

--- a/packages/happy-css-modules/src/transformer/scss-transformer.test.ts
+++ b/packages/happy-css-modules/src/transformer/scss-transformer.test.ts
@@ -46,7 +46,7 @@ test('handles sass features', async () => {
   // FIXME: The end position of 'a_2_2' is incorrect.
   expect(result).toMatchInlineSnapshot(`
     {
-      dependencies: ["<fixtures>/test/2.scss", "<fixtures>/test/3.scss", "<fixtures>/test/4.scss"],
+      dependencies: ["<fixtures>/test/2.scss", "<fixtures>/test/3.scss"],
       tokens: [
         {
           name: "b_1",
@@ -83,12 +83,6 @@ test('handles sass features', async () => {
           name: "a_2_2",
           originalLocations: [
             { filePath: "<fixtures>/test/1.scss", start: { line: 8, column: 3 }, end: { line: 8, column: 8 } },
-          ],
-        },
-        {
-          name: "d",
-          originalLocations: [
-            { filePath: "<fixtures>/test/4.scss", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
           ],
         },
       ],


### PR DESCRIPTION
Assume you have the following CSS Modules file

```css
/* a.module.css */
.foo {
  composes: bar from "./b.module.css";
}
```

```css
/* b.module.css */
.bar {
  color: blue;
}
```

happy-css-modules interprets that the classes `a` and `b` (internally called "token") are exported from a.module.css. Then happy-css-modules generates .d.ts like this

```ts
// a.module.css.d.ts
declare const styles:
  & Readonly<{ "foo": string }>
  & Readonly<Pick<(typeof import("./2.css"))["default"], "bar">>
;
export default styles;
```

But this is wrong: the css-loader treats only `a` tokens from a.module.css as if they were exported.

- https://github.com/mizdra/css-modules-example/commit/41e8f6f5d18ebee849c48a6a0b3e072dd08bb5b0#r142285470

So we decided to change the behavior of happy-css-modules, so that it generates .d.ts like this

```ts
// a.module.css.d.ts
declare const styles:
  & Readonly<{ "foo": string }>
;
export default styles;
```