### PR TITLE
fix: watch mode not working on Windows

### DIFF
--- a/packages/happy-css-modules/src/util.ts
+++ b/packages/happy-css-modules/src/util.ts
@@ -66,7 +66,7 @@ export async function exists(path: string): Promise<boolean> {
 }
 
 export function isMatchByGlob(filePath: string, pattern: string, options: { cwd: string }): boolean {
-  return minimatch(filePath, join(options.cwd, pattern));
+  return minimatch(filePath, join(options.cwd, pattern), { windowsPathsNoEscape: true });
 }
 
 export function getPackageJson() {


### PR DESCRIPTION
I met an issue when i ran `npx hcm 'src/**/*.module.{css,scss,less}' --watch` on Windows 10. It will not generate the css file.

After some debugging, I found that the callback passed to watcher in not working correctly. The flow will always early returned in `if (isExternalFile(filePath))`, and I found that the root cause of the problem is that `isMatchByGlob` in `src/util.ts` always return false. This function call `minimatch` from `minimatch`.

The smallest reproduce code is as follows:

```js
import { minimatch } from 'minimatch';
const path = 'D:\\awesome project\\src\\style\\index.module.less';
const pattern = 'D:\\awesome project\\src\\**\\*.module.less';
const matched = minimatch(path, pattern);
// matched: false
```

I found that `minimatch` has a third argument options on its repo's README. I tried to set `options.windowsPathsNoEscape` to true, and it works.

```js
import { minimatch } from 'minimatch';
const path = 'D:\\awesome project\\src\\style\\index.module.less';
const pattern = 'D:\\awesome project\\src\\**\\*.module.less';
const matched = minimatch(path, pattern, { windowsPathsNoEscape: true });
// matched: true
```
