### PR TITLE
Token has only one `originalLocation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,23 +224,19 @@ assert.deepEqual(result, {
   tokens: [
     {
       name: 'b',
-      originalLocations: [
-        {
-          filePath: '/Users/mizdra/src/github.com/mizdra/packages/example/02-import/3.css',
-          start: { line: 1, column: 1 },
-          end: { line: 1, column: 2 },
-        },
-      ],
+      originalLocation: {
+        filePath: '/Users/mizdra/src/github.com/mizdra/packages/example/02-import/3.css',
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 2 },
+      },
     },
     {
       name: 'a',
-      originalLocations: [
-        {
-          filePath: '/Users/mizdra/src/github.com/mizdra/packages/example/02-import/2.css',
-          start: { line: 3, column: 1 },
-          end: { line: 3, column: 2 },
-        },
-      ],
+      originalLocation: {
+        filePath: '/Users/mizdra/src/github.com/mizdra/packages/example/02-import/2.css',
+        start: { line: 3, column: 1 },
+        end: { line: 3, column: 2 },
+      },
     },
   ],
 });

--- a/packages/happy-css-modules/src/emitter/dts.ts
+++ b/packages/happy-css-modules/src/emitter/dts.ts
@@ -62,41 +62,40 @@ function generateTokenDeclarations(
     // This is due to the sourcemap specification. Therefore, we output multiple type definitions
     // with the same name and assign a separate original position to each.
 
-    for (let originalLocation of token.originalLocations) {
-      if (originalLocation.filePath === undefined) {
-        // If the original location is not specified, fallback to the source file.
-        originalLocation = {
-          filePath,
-          start: { line: 1, column: 1 },
-          end: { line: 1, column: 1 },
-        };
-      }
-
-      result.push(
-        originalLocation.filePath === filePath || isExternalFile(originalLocation.filePath)
-          ? new SourceNode(null, null, null, [
-              '& Readonly<{ ',
-              new SourceNode(
-                originalLocation.start.line ?? null,
-                // The SourceNode's column is 0-based, but the originalLocation's column is 1-based.
-                originalLocation.start.column - 1 ?? null,
-                getRelativePath(sourceMapFilePath, originalLocation.filePath),
-                `"${token.name}"`,
-                token.name,
-              ),
-              ': string }>',
-            ])
-          : // Imported tokens in non-external files are typed by dynamic import.
-            // See https://github.com/mizdra/happy-css-modules/issues/106.
-            new SourceNode(null, null, null, [
-              '& Readonly<Pick<(typeof import(',
-              `"${getRelativePath(filePath, originalLocation.filePath)}"`,
-              '))["default"], ',
-              `"${token.name}"`,
-              '>>',
-            ]),
-      );
+    let originalLocation = token.originalLocation;
+    if (originalLocation.filePath === undefined) {
+      // If the original location is not specified, fallback to the source file.
+      originalLocation = {
+        filePath,
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 1 },
+      };
     }
+
+    result.push(
+      originalLocation.filePath === filePath || isExternalFile(originalLocation.filePath)
+        ? new SourceNode(null, null, null, [
+            '& Readonly<{ ',
+            new SourceNode(
+              originalLocation.start.line ?? null,
+              // The SourceNode's column is 0-based, but the originalLocation's column is 1-based.
+              originalLocation.start.column - 1 ?? null,
+              getRelativePath(sourceMapFilePath, originalLocation.filePath),
+              `"${token.name}"`,
+              token.name,
+            ),
+            ': string }>',
+          ])
+        : // Imported tokens in non-external files are typed by dynamic import.
+          // See https://github.com/mizdra/happy-css-modules/issues/106.
+          new SourceNode(null, null, null, [
+            '& Readonly<Pick<(typeof import(',
+            `"${getRelativePath(filePath, originalLocation.filePath)}"`,
+            '))["default"], ',
+            `"${token.name}"`,
+            '>>',
+          ]),
+    );
   }
   return result;
 }

--- a/packages/happy-css-modules/src/emitter/index.test.ts
+++ b/packages/happy-css-modules/src/emitter/index.test.ts
@@ -25,7 +25,7 @@ test('isSubDirectoryFile', () => {
 describe('emitGeneratedFiles', () => {
   const defaultArgs = {
     filePath: getFixturePath('/test/1.css'),
-    tokens: [fakeToken({ name: 'foo', originalLocations: [{ start: { line: 1, column: 1 } }] })],
+    tokens: [fakeToken({ name: 'foo', originalLocation: { start: { line: 1, column: 1 } } })],
     emitDeclarationMap: true,
     dtsFormatOptions: undefined,
     cwd: getFixturePath('/test'),
@@ -55,7 +55,7 @@ describe('emitGeneratedFiles', () => {
     expect(await exists(getFixturePath('/test/1.css.d.ts.map'))).toBeFalsy();
   });
   test('skips writing to disk if the generated files are the same', async () => {
-    const tokens1 = [fakeToken({ name: 'foo', originalLocations: [{ start: { line: 1, column: 1 } }] })];
+    const tokens1 = [fakeToken({ name: 'foo', originalLocation: { start: { line: 1, column: 1 } } })];
     await emitGeneratedFiles({ ...defaultArgs, tokens: tokens1 });
     const mtimeForDts1 = (await stat(getFixturePath('/test/1.css.d.ts'))).mtime;
     const mtimeForSourceMap1 = (await stat(getFixturePath('/test/1.css.d.ts.map'))).mtime;
@@ -68,7 +68,7 @@ describe('emitGeneratedFiles', () => {
     expect(mtimeForSourceMap1).toEqual(mtimeForSourceMap2); // skipped
 
     await waitForAsyncTask(1); // so that mtime changes.
-    const tokens2 = [fakeToken({ name: 'bar', originalLocations: [{ start: { line: 1, column: 1 } }] })];
+    const tokens2 = [fakeToken({ name: 'bar', originalLocation: { start: { line: 1, column: 1 } } })];
     await emitGeneratedFiles({ ...defaultArgs, tokens: tokens2 });
     const mtimeForDts3 = (await stat(getFixturePath('/test/1.css.d.ts'))).mtime;
     const mtimeForSourceMap3 = (await stat(getFixturePath('/test/1.css.d.ts.map'))).mtime;

--- a/packages/happy-css-modules/src/locator/index.test.ts
+++ b/packages/happy-css-modules/src/locator/index.test.ts
@@ -22,15 +22,19 @@ test('basic', async () => {
       tokens: [
         {
           name: "a",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
         {
           name: "b",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.css", start: { line: 2, column: 1 }, end: { line: 2, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.css",
+            start: { line: 2, column: 1 },
+            end: { line: 2, column: 2 },
+          },
         },
       ],
     }
@@ -74,27 +78,35 @@ test('tracks other files when `@import` is present', async () => {
       tokens: [
         {
           name: "a",
-          originalLocations: [
-            { filePath: "<fixtures>/test/2.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/2.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
         {
           name: "b",
-          originalLocations: [
-            { filePath: "<fixtures>/test/3.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/3.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
         {
           name: "c",
-          originalLocations: [
-            { filePath: "<fixtures>/test/4.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/4.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
         {
           name: "d",
-          originalLocations: [
-            { filePath: "<fixtures>/test/5-recursive.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/5-recursive.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
       ],
     }
@@ -120,16 +132,18 @@ test('does not track other files by `composes`', async () => {
       tokens: [
         {
           name: "a",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
       ],
     }
   `);
 });
 
-test('normalizes tokens', async () => {
+test('unique tokens', async () => {
   createFixtures({
     '/test/1.css': dedent`
     /* duplicate import */
@@ -142,9 +156,6 @@ test('normalizes tokens', async () => {
     .a {} /* class selector that duplicates the import source */
     .b {}
     `,
-    '/test/3.css': dedent`
-    .c {}
-    `,
   });
   const result = await locator.load(getFixturePath('/test/1.css'));
   expect(result).toMatchInlineSnapshot(`
@@ -153,17 +164,35 @@ test('normalizes tokens', async () => {
       tokens: [
         {
           name: "a",
-          originalLocations: [
-            { filePath: "<fixtures>/test/2.css", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-            { filePath: "<fixtures>/test/1.css", start: { line: 4, column: 1 }, end: { line: 4, column: 2 } },
-            { filePath: "<fixtures>/test/1.css", start: { line: 5, column: 1 }, end: { line: 5, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/2.css",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
         {
           name: "b",
-          originalLocations: [
-            { filePath: "<fixtures>/test/2.css", start: { line: 2, column: 1 }, end: { line: 2, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/2.css",
+            start: { line: 2, column: 1 },
+            end: { line: 2, column: 2 },
+          },
+        },
+        {
+          name: "a",
+          originalLocation: {
+            filePath: "<fixtures>/test/1.css",
+            start: { line: 4, column: 1 },
+            end: { line: 4, column: 2 },
+          },
+        },
+        {
+          name: "a",
+          originalLocation: {
+            filePath: "<fixtures>/test/1.css",
+            start: { line: 5, column: 1 },
+            end: { line: 5, column: 2 },
+          },
         },
       ],
     }
@@ -233,16 +262,27 @@ describe('supports sourcemap', () => {
         tokens: [
           {
             name: "nesting",
-            originalLocations: [
-              { filePath: "<fixtures>/test/1.scss", start: { line: 1, column: 1 }, end: { line: 1, column: 8 } },
-              { filePath: "<fixtures>/test/1.scss", start: { line: 3, column: 3 }, end: { line: 3, column: 10 } },
-            ],
+            originalLocation: {
+              filePath: "<fixtures>/test/1.scss",
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 8 },
+            },
+          },
+          {
+            name: "nesting",
+            originalLocation: {
+              filePath: "<fixtures>/test/1.scss",
+              start: { line: 3, column: 3 },
+              end: { line: 3, column: 10 },
+            },
           },
           {
             name: "nesting_child",
-            originalLocations: [
-              { filePath: "<fixtures>/test/1.scss", start: { line: 3, column: 3 }, end: { line: 3, column: 16 } },
-            ],
+            originalLocation: {
+              filePath: "<fixtures>/test/1.scss",
+              start: { line: 3, column: 3 },
+              end: { line: 3, column: 16 },
+            },
           },
         ],
       }
@@ -272,18 +312,22 @@ describe('supports sourcemap', () => {
         tokens: [
           {
             name: "selector_list_a_1",
-            originalLocations: [
-              { filePath: "<fixtures>/test/1.css", start: { line: 1, column: 1 }, end: { line: 1, column: 18 } },
-            ],
+            originalLocation: {
+              filePath: "<fixtures>/test/1.css",
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 18 },
+            },
           },
           {
             name: "selector_list_a_2",
-            originalLocations: [
-              { filePath: "<fixtures>/test/1.css", start: { line: 1, column: 1 }, end: { line: 1, column: 18 } },
-            ],
+            originalLocation: {
+              filePath: "<fixtures>/test/1.css",
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 18 },
+            },
           },
-          { name: "selector_list_b_1", originalLocations: [{}] },
-          { name: "selector_list_b_2", originalLocations: [{}] },
+          { name: "selector_list_b_1", originalLocation: {} },
+          { name: "selector_list_b_2", originalLocation: {} },
         ],
       }
     `);

--- a/packages/happy-css-modules/src/locator/index.ts
+++ b/packages/happy-css-modules/src/locator/index.ts
@@ -20,8 +20,8 @@ function isIgnoredSpecifier(specifier: string): boolean {
 export type Token = {
   /** The token name. */
   name: string;
-  /** The original locations of the token in the source file. */
-  originalLocations: Location[];
+  /** The original location of the token in the source file. */
+  originalLocation: Location;
 };
 
 type CacheEntry = {
@@ -36,22 +36,6 @@ export type LoadResult = {
   /** The tokens exported by the source file. */
   tokens: Token[];
 };
-
-function normalizeTokens(tokens: Token[]): Token[] {
-  const tokenNameToOriginalLocations = new Map<string, Location[]>();
-  for (const token of tokens) {
-    tokenNameToOriginalLocations.set(
-      token.name,
-      uniqueBy([...(tokenNameToOriginalLocations.get(token.name) ?? []), ...token.originalLocations], (location) =>
-        JSON.stringify(location),
-      ),
-    );
-  }
-  return Array.from(tokenNameToOriginalLocations.entries()).map(([name, originalLocations]) => ({
-    name,
-    originalLocations,
-  }));
-}
 
 export type LocatorOptions = {
   /** The function to transform source code. */
@@ -184,13 +168,13 @@ export class Locator {
 
       tokens.push({
         name: classSelector.value,
-        originalLocations: [originalLocation],
+        originalLocation,
       });
     }
 
     const result: LoadResult = {
       dependencies: unique(dependencies).filter((dep) => dep !== filePath),
-      tokens: normalizeTokens(tokens),
+      tokens: uniqueBy(tokens, (token) => JSON.stringify(token)),
     };
     this.cache.set(filePath, { mtime, result });
     return result;

--- a/packages/happy-css-modules/src/test-util/util.ts
+++ b/packages/happy-css-modules/src/test-util/util.ts
@@ -27,25 +27,26 @@ export function createClassSelectors(root: Root): { rule: Rule; classSelector: C
 
 export function fakeToken(args: {
   name: Token['name'];
-  originalLocations: { filePath?: Location['filePath']; start?: Location['start'] }[];
+  originalLocation: { filePath?: Location['filePath']; start?: Location['start'] };
 }): Token {
-  return {
-    name: args.name,
-    originalLocations: args.originalLocations.map((location) => {
-      if (location.filePath === undefined || location.start === undefined) {
-        return { filePath: undefined, start: undefined, end: undefined };
-      } else {
-        return {
-          filePath: location.filePath ?? getFixturePath('/test/1.css'),
-          start: location.start,
-          end: {
-            line: location.start.line,
-            column: location.start.column + args.name.length - 1,
-          },
-        };
-      }
-    }),
-  };
+  if (args.originalLocation.filePath === undefined || args.originalLocation.start === undefined) {
+    return {
+      name: args.name,
+      originalLocation: { filePath: undefined, start: undefined, end: undefined },
+    };
+  } else {
+    return {
+      name: args.name,
+      originalLocation: {
+        filePath: args.originalLocation.filePath ?? getFixturePath('/test/1.css'),
+        start: args.originalLocation.start,
+        end: {
+          line: args.originalLocation.start.line,
+          column: args.originalLocation.start.column + args.name.length - 1,
+        },
+      },
+    };
+  }
 }
 
 export async function waitForAsyncTask(ms?: number): Promise<void> {

--- a/packages/happy-css-modules/src/transformer/less-transformer.test.ts
+++ b/packages/happy-css-modules/src/transformer/less-transformer.test.ts
@@ -42,33 +42,43 @@ test('handles less features', async () => {
       tokens: [
         {
           name: "b_1",
-          originalLocations: [
-            { filePath: "<fixtures>/test/2.less", start: { line: 1, column: 1 }, end: { line: 1, column: 4 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/2.less",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 4 },
+          },
         },
         {
           name: "a_1",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.less", start: { line: 2, column: 1 }, end: { line: 2, column: 4 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.less",
+            start: { line: 2, column: 1 },
+            end: { line: 2, column: 4 },
+          },
         },
         {
           name: "a_2",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.less", start: { line: 3, column: 1 }, end: { line: 3, column: 4 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.less",
+            start: { line: 3, column: 1 },
+            end: { line: 3, column: 4 },
+          },
         },
         {
           name: "a_2_1",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.less", start: { line: 6, column: 3 }, end: { line: 6, column: 8 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.less",
+            start: { line: 6, column: 3 },
+            end: { line: 6, column: 8 },
+          },
         },
         {
           name: "a_2_2",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.less", start: { line: 7, column: 3 }, end: { line: 7, column: 8 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.less",
+            start: { line: 7, column: 3 },
+            end: { line: 7, column: 8 },
+          },
         },
       ],
     }

--- a/packages/happy-css-modules/src/transformer/postcss-transformer.test.ts
+++ b/packages/happy-css-modules/src/transformer/postcss-transformer.test.ts
@@ -41,9 +41,11 @@ test('handles postcss features', async () => {
       tokens: [
         {
           name: "foo_bar",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.css", start: { line: 2, column: 1 }, end: { line: 2, column: 8 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.css",
+            start: { line: 2, column: 1 },
+            end: { line: 2, column: 8 },
+          },
         },
       ],
     }

--- a/packages/happy-css-modules/src/transformer/scss-transformer.test.ts
+++ b/packages/happy-css-modules/src/transformer/scss-transformer.test.ts
@@ -48,40 +48,59 @@ test('handles sass features', async () => {
       tokens: [
         {
           name: "b_1",
-          originalLocations: [
-            { filePath: "<fixtures>/test/2.scss", start: { line: 1, column: 1 }, end: { line: 1, column: 4 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/2.scss",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 4 },
+          },
         },
         {
           name: "c",
-          originalLocations: [
-            { filePath: "<fixtures>/test/3.scss", start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/3.scss",
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 2 },
+          },
         },
         {
           name: "a_1",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.scss", start: { line: 3, column: 1 }, end: { line: 3, column: 4 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.scss",
+            start: { line: 3, column: 1 },
+            end: { line: 3, column: 4 },
+          },
         },
         {
           name: "a_2",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.scss", start: { line: 4, column: 1 }, end: { line: 4, column: 4 } },
-            { filePath: "<fixtures>/test/1.scss", start: { line: 7, column: 3 }, end: { line: 7, column: 6 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.scss",
+            start: { line: 4, column: 1 },
+            end: { line: 4, column: 4 },
+          },
+        },
+        {
+          name: "a_2",
+          originalLocation: {
+            filePath: "<fixtures>/test/1.scss",
+            start: { line: 7, column: 3 },
+            end: { line: 7, column: 6 },
+          },
         },
         {
           name: "a_2_1",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.scss", start: { line: 7, column: 3 }, end: { line: 7, column: 8 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.scss",
+            start: { line: 7, column: 3 },
+            end: { line: 7, column: 8 },
+          },
         },
         {
           name: "a_2_2",
-          originalLocations: [
-            { filePath: "<fixtures>/test/1.scss", start: { line: 8, column: 3 }, end: { line: 8, column: 8 } },
-          ],
+          originalLocation: {
+            filePath: "<fixtures>/test/1.scss",
+            start: { line: 8, column: 3 },
+            end: { line: 8, column: 8 },
+          },
         },
       ],
     }


### PR DESCRIPTION
## Breaking Changes

### The token has only one `originalLocation`

Previously, a token returned `Locator#load` could have multiple `OriginalLocation`.

```ts
const filePath = resolve('example/02-import/2.css'); // Convert to absolute path
const result = await locator.load(filePath);

assert.deepEqual(result, {
  dependencies: ['/path/to/1.css'],
  tokens: [
    {
      name: 'a',
      originalLocations: [
        {
          filePath: '/path/to/1.css',
          start: { line: 1, column: 1 },
          end: { line: 1, column: 2 },
        },
        {
          filePath: '/path/to/1.css',
          start: { line: 2, column: 1 },
          end: { line: 2, column: 2 },
        },
      ],
    },
  ],
});
```

From now on, each token will have one `OriginalLocation`.

```ts
const filePath = resolve('example/02-import/2.css'); // Convert to absolute path
const result = await locator.load(filePath);

assert.deepEqual(result, {
  dependencies: ['/path/to/1.css'],
  tokens: [
    {
      name: 'a',
      originalLocation: {
        filePath: '/path/to/1.css',
        start: { line: 1, column: 1 },
        end: { line: 1, column: 2 },
      },
    },
    {
      name: 'a',
      originalLocation: {
        filePath: '/path/to/1.css',
        start: { line: 2, column: 1 },
        end: { line: 2, column: 2 },
      },
    },
  ],
});
```

`Locator#load` is part of the experimental Programmable API. Therefore, this change is shipped as a minor update.