### PR TITLE
feat: Use the modern API of sass

### DIFF
--- a/packages/happy-css-modules/src/transformer/scss-transformer.ts
+++ b/packages/happy-css-modules/src/transformer/scss-transformer.ts
@@ -1,42 +1,26 @@
-// NOTE: The workaround for using sass's modern API. happy-css-modules used to use this API.
-// However, due to the implementation of custom resolvers, we have switched to the legacy API.
-// Therefore, the workaround is now disabled. See
-// https://github.com/mizdra/happy-css-modules/issues/65#issuecomment-1229471950 for more information.
-
-import type { LegacyOptions, LegacyResult } from 'sass';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { FileImporter } from 'sass';
+import type { StrictlyResolver } from '../locator/index.js';
 import type { Transformer } from './index.js';
 import { handleImportError } from './index.js';
 
-// For some reason, `util.promisify` does not work. Therefore, use the original promisify.
-function promisifySassRender(sass: typeof import('sass')) {
-  return async (options: LegacyOptions<'async'>) => {
-    return new Promise<LegacyResult>((resolve, reject) => {
-      sass.render(options, (exception, result) => {
-        if (exception) reject(exception);
-        else resolve(result!);
-      });
-    });
-  };
-}
+const createFileImporter: (resolver: StrictlyResolver) => FileImporter<'async'> = (resolver) => ({
+  async findFileUrl(url, context): Promise<URL> {
+    const path = await resolver(url, { request: fileURLToPath(context.containingUrl!) });
+    return pathToFileURL(path);
+  },
+});
 
 export const createScssTransformer: () => Transformer = () => {
   let sass: typeof import('sass');
   return async (source, options) => {
     // eslint-disable-next-line require-atomic-updates
     sass ??= await import('sass').catch(handleImportError('sass'));
-    const render = promisifySassRender(sass);
-    const result = await render({
-      data: source,
-      file: options.from,
-      outFile: 'DUMMY', // Required for sourcemap output.
+    const result = await sass.compileStringAsync(source, {
+      url: pathToFileURL(options.from),
       sourceMap: true,
-      importer: (url, prev, done) => {
-        options
-          .resolver(url, { request: prev })
-          .then((resolved) => done({ file: resolved }))
-          .catch((e) => done(e));
-      },
+      importers: [createFileImporter(options.resolver)],
     });
-    return { css: result.css.toString(), map: result.map!.toString(), dependencies: result.stats.includedFiles };
+    return { css: result.css.toString(), map: JSON.stringify(result.sourceMap!), dependencies: result.loadedUrls };
   };
 };


### PR DESCRIPTION
ref: https://github.com/mizdra/happy-css-modules/issues/65#issuecomment-1229471950

The modern API of sass now has `containingUrl` to determine where the import was ocurred, so we can safely migrate from the legacy API to the modern API of sass.